### PR TITLE
fix: pin dependency versions to prevent slow resolution and silent version downgrade

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,11 +1,24 @@
-huggingface_hub==0.22.2
-python-dotenv
-langchain
-langchain-openai
-langchain-community
-langchain-text-splitters
-chromadb
-gradio
-openai
-uvicorn
-pydantic
+# Core AI/LLM
+huggingface-hub==0.22.2
+openai==2.36.0
+langchain==1.2.17
+langchain-openai==1.2.1
+langchain-community==0.4.1
+langchain-text-splitters==1.1.2
+
+# Vector DB
+chromadb==1.5.9
+
+# UI
+# gradio is constrained to 4.44.1 due to huggingface-hub==0.22.2
+# Upgrading huggingface-hub to >=0.30.0 would allow gradio 6.x
+gradio==4.44.1
+
+# Web server
+uvicorn==0.46.0
+
+# Data validation
+pydantic==2.13.4
+
+# Utils
+python-dotenv==1.2.2


### PR DESCRIPTION
## What does this PR do?
Pins all direct dependencies in requirements.txt to their verified 
compatible versions.

## Why?
Closes [AI-217](https://mifosforge.jira.com/browse/AI-217)

Running `pip install -r requirements.txt` currently causes pip to backtrack 
through 90+ versions of gradio before settling on `gradio==4.44.1` (2 major 
versions behind current 6.x). Root cause is `huggingface_hub==0.22.2` 
conflicting with modern gradio. All other packages were completely unpinned 
making installs unpredictable across machines.

## Changes
- Pinned all direct dependencies to verified compatible versions
- Added inline comments explaining the gradio version constraint

## Testing
pip install -r requirements.txt
pip check  # No broken requirements found

[AI-217]: https://mifosforge.jira.com/browse/AI-217?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ